### PR TITLE
Remove unneeded manual jwt expiry validation

### DIFF
--- a/backend/authentication/utils/validate_jwt.py
+++ b/backend/authentication/utils/validate_jwt.py
@@ -1,5 +1,3 @@
-from datetime import datetime, timezone
-
 import jwt
 from django.conf import settings
 
@@ -13,12 +11,6 @@ def validate_jwt(token: str) -> dict:
 
     try:
         payload = jwt.decode(token, settings.SECRET_KEY, algorithms=["HS256"])
-        exp = payload.get("exp")
-        if exp is None:
-            raise ValueError("Token missing expiration")
-
-        if datetime.now(timezone.utc).timestamp() > exp:
-            raise ValueError("Token expired")
 
         id = payload.get("user_id")
         if id is None:


### PR DESCRIPTION
Closes #14 
Removes the manual JWT expiry check from the JWT validation util. This check is done in jwt.decode() and the exception is caught.