### PR TITLE
Add custom jwt error class

### DIFF
--- a/backend/authentication/exceptions.py
+++ b/backend/authentication/exceptions.py
@@ -14,24 +14,30 @@ class UserError(JWTValidationError):
 
 
 class MissingUserIdError(TokenError):
-    pass
+    def __str__() -> str:
+        return "Token missing user ID."
 
 
 class AccountInactiveError(UserError):
-    pass
+    def __str__(self) -> str:
+        return "User account inactive. ID: ${self.user_id}."
 
 
 class TokenExpiredError(TokenError):
-    pass
+    def __str__() -> str:
+        return "Token expired."
 
 
 class InvalidTokenError(TokenError):
-    pass
+    def __str__() -> str:
+        return "Token invalid."
 
 
 class UserDoesNotExistError(UserError):
-    pass
+    def __str__(self) -> str:
+        return "User does not exist. ID: ${self.user_id}."
 
 
 class NoTokenProvidedError(TokenError):
-    pass
+    def __str__() -> str:
+        return "No token provided."

--- a/backend/authentication/exceptions.py
+++ b/backend/authentication/exceptions.py
@@ -7,7 +7,10 @@ class TokenError(JWTValidationError):
 
 
 class UserError(JWTValidationError):
-    pass
+    user_id: str = None
+
+    def __init__(self, id: str) -> None:
+        self.user_id = id
 
 
 class MissingUserIdError(TokenError):

--- a/backend/authentication/exceptions.py
+++ b/backend/authentication/exceptions.py
@@ -26,5 +26,9 @@ class InvalidTokenError(TokenError):
     pass
 
 
-class UserDoesNotExist(UserError):
+class UserDoesNotExistError(UserError):
+    pass
+
+
+class NoTokenProvidedError(TokenError):
     pass

--- a/backend/authentication/exceptions.py
+++ b/backend/authentication/exceptions.py
@@ -1,0 +1,30 @@
+class JWTValidationError(Exception):
+    pass
+
+
+class TokenError(JWTValidationError):
+    pass
+
+
+class UserError(JWTValidationError):
+    pass
+
+
+class MissingUserIdError(TokenError):
+    pass
+
+
+class AccountInactiveError(UserError):
+    pass
+
+
+class TokenExpiredError(TokenError):
+    pass
+
+
+class InvalidTokenError(TokenError):
+    pass
+
+
+class UserDoesNotExist(UserError):
+    pass

--- a/backend/authentication/utils/validate_jwt.py
+++ b/backend/authentication/utils/validate_jwt.py
@@ -1,5 +1,3 @@
-from datetime import datetime, timezone
-
 import jwt
 from django.conf import settings
 
@@ -13,12 +11,6 @@ def validate_jwt(token: str) -> dict:
 
     try:
         payload = jwt.decode(token, settings.SECRET_KEY, algorithms=["HS256"])
-        exp = payload.get("exp")
-        if exp is None:
-            raise ValueError("Token missing expiration")
-
-        if datetime.now(timezone.utc).timestamp() > exp:
-            raise ValueError("Token expired")
 
         id = payload.get("user_id")
         if id is None:

--- a/backend/authentication/utils/validate_jwt.py
+++ b/backend/authentication/utils/validate_jwt.py
@@ -1,3 +1,4 @@
+import exceptions
 import jwt
 from django.conf import settings
 
@@ -7,24 +8,24 @@ from authentication.models import DenbotUser
 def validate_jwt(token: str) -> dict:
     """Return payload if valid, else raise exception"""
     if not token:
-        raise ValueError("No token provided")
+        raise exceptions.NoTokenProvidedError
 
     try:
         payload = jwt.decode(token, settings.SECRET_KEY, algorithms=["HS256"])
 
         id = payload.get("user_id")
         if id is None:
-            raise ValueError("Token missing user id")
+            raise exceptions.MissingUserIdError
 
         user = DenbotUser.objects.get(id=id)
         if not user.is_active:
-            raise ValueError("User account not active")
+            raise exceptions.AccountInactiveError
 
         return payload
 
     except jwt.ExpiredSignatureError:
-        raise ValueError("Token expired")
+        raise exceptions.TokenExpiredError
     except jwt.InvalidTokenError:
-        raise ValueError("Invalid token")
+        raise exceptions.InvalidTokenError
     except DenbotUser.DoesNotExist:
-        raise ValueError("User Does Not Exist")
+        raise exceptions.UserDoesNotExistError

--- a/backend/authentication/utils/validate_jwt.py
+++ b/backend/authentication/utils/validate_jwt.py
@@ -1,31 +1,31 @@
-import exceptions
 import jwt
 from django.conf import settings
 
+import authentication.exceptions as jwtExceptions
 from authentication.models import DenbotUser
 
 
 def validate_jwt(token: str) -> dict:
     """Return payload if valid, else raise exception"""
     if not token:
-        raise exceptions.NoTokenProvidedError
+        raise jwtExceptions.NoTokenProvidedError
 
     try:
         payload = jwt.decode(token, settings.SECRET_KEY, algorithms=["HS256"])
 
         id = payload.get("user_id")
         if id is None:
-            raise exceptions.MissingUserIdError
+            raise jwtExceptions.MissingUserIdError
 
         user = DenbotUser.objects.get(id=id)
         if not user.is_active:
-            raise exceptions.AccountInactiveError
+            raise jwtExceptions.AccountInactiveError(id)
 
         return payload
 
     except jwt.ExpiredSignatureError:
-        raise exceptions.TokenExpiredError
+        raise jwtExceptions.TokenExpiredError
     except jwt.InvalidTokenError:
-        raise exceptions.InvalidTokenError
+        raise jwtExceptions.InvalidTokenError
     except DenbotUser.DoesNotExist:
-        raise exceptions.UserDoesNotExistError
+        raise jwtExceptions.UserDoesNotExistError(id)

--- a/backend/authentication/views.py
+++ b/backend/authentication/views.py
@@ -6,6 +6,7 @@ from django.http import HttpRequest
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from authentication.exceptions import JWTValidationError
 from authentication.models import DenbotUser
 from authentication.utils.twilio_auth import (
     try_twilio_auth_create,
@@ -73,5 +74,5 @@ class JWTVerificationView(APIView):
         try:
             payload = validate_jwt(token)
             return Response({"valid": True, "user_id": payload.get("user_id")})
-        except ValueError as e:
+        except JWTValidationError as e:
             return Response({"valid": False, "reason": str(e)}, status=401)


### PR DESCRIPTION
Closes #5 
Add custom error classes to the authentication site for JWT decoding/validation. 
Classes extend a base class for the suite of exceptions, and 2 subclasses, UserError and TokenError. Should make exception handling much nicer.